### PR TITLE
Upgrade s3cmd to v1.6.0

### DIFF
--- a/wercker.yml
+++ b/wercker.yml
@@ -8,7 +8,7 @@ build:
         - script:
             name: set version
             code: |
-                export S3CMD_VERSION="1.5.1.2"
+                export S3CMD_VERSION="1.6.0"
                 echo "Installing version $S3CMD_VERSION of s3cmd"
 
         - script:


### PR DESCRIPTION
There are two issues #20 #21 noting that S3 errors don't result in a failed deploy.  This is because `s3cmd sync` is not exiting non 0 on error.

I opened s3tools/s3cmd#649 to correct this.  They claim the latest version, 1.6.0 addresses this.  This PR updates to the latest version.