### PR TITLE
Updating Policy With Version

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ It's a good idea to create a IAM user which just has enough permissions to be ab
 
 ```
 {
+  "Version": "2012-10-17",
   "Statement": [
     {
       "Action": [


### PR DESCRIPTION
Managed policies require a version string. If you try to create the policy in this documentation you get the following error:
>This policy contains the following error: A managed policy must have a version string For more information about the IAM policy grammar, see [AWS IAM Policies](http://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_grammar.html).