### PR TITLE
Allow adding additional s3cmd command

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -65,6 +65,22 @@ main() {
       echo "$sync_output"
       success 'finished s3 synchronisation';
   fi
+
+  if [ -n "$WERCKER_S3SYNC_ADDITIONAL_COMMAND" ]; then
+    debug "Executing additional command"
+    local ADDITIONAL="$WERCKER_STEP_ROOT/s3cmd $WERCKER_S3SYNC_ADDITIONAL_COMMAND"
+    debug "$ADDITIONAL"
+    local additional_output=$($ADDITIONAL)
+
+    if [[ $? -ne 0 ]];then
+        echo "$additional_output"
+        fail 's3cmd additional failed';
+    else
+        echo "$additional_output"
+        success 'finished s3 additional';
+    fi
+  fi
+
   set -e
 }
 


### PR DESCRIPTION
Use case:

we use Cloudfront in front of S3, we upload a web app to s3. We don't want index.html to be cached (while others can have default caching). We achieve that by adding the following extra command now: `additional-command: put --acl-public --force --add-header=Cache-Control:no-cache index.html $S3_BUCKET`

Let me know if you would like that in the main project as well, and if yes, what other changes need to be done, e.g. version needs to be bumped or something.

