### PR TITLE
Update s3cmd to 1.6.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,10 @@ The MIT License (MIT)
 
 # Changelog
 
+## 2.2.2
+
+- Update s3cmd to 1.6.1
+
 ## 2.0.3
 
 - Always display s3cmd output

--- a/step.yml
+++ b/step.yml
@@ -1,5 +1,5 @@
 name: s3sync
-version: 2.2.1
+version: 2.2.2
 summary: s3sync step
 tags:
 - s3

--- a/wercker.yml
+++ b/wercker.yml
@@ -8,7 +8,7 @@ build:
         - script:
             name: set version
             code: |
-                export S3CMD_VERSION="1.6.0"
+                export S3CMD_VERSION="1.6.1"
                 echo "Installing version $S3CMD_VERSION of s3cmd"
 
         - install-packages:


### PR DESCRIPTION
This pull request updates the s3cmd to 1.6.1.   Updating to 1.6.1 fixed an issue a customer was seeing when running the wercker/s3sync step.

See discussion at https://werckerpublic.slack.com/archives/C0B8P1XJ5/p1535375661000100 where the issue was discussed.